### PR TITLE
Bump to eclipse photon (#72)

### DIFF
--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.debugger.ui/META-INF/MANIFEST.MF
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.debugger.ui/META-INF/MANIFEST.MF
@@ -32,4 +32,5 @@ Require-Bundle: com.google.guava,
  org.eclipse.debug.ui,
  org.eclipse.emf.transaction;bundle-version="1.9.0"
 Bundle-ActivationPolicy: lazy
+Automatic-Module-Name: org.eclipse.gemoc.executionframework.debugger.ui
 

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.debugger/META-INF/MANIFEST.MF
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.debugger/META-INF/MANIFEST.MF
@@ -30,4 +30,5 @@ Require-Bundle: com.google.guava,
  org.eclipse.gemoc.trace.gemoc.api;bundle-version="3.0.0"
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.gemoc.executionframework.debugger
+Automatic-Module-Name: org.eclipse.gemoc.executionframework.debugger
 

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine.ui/META-INF/MANIFEST.MF
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine.ui/META-INF/MANIFEST.MF
@@ -29,3 +29,4 @@ Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.gemoc.executionframework.engine.ui,
  org.eclipse.gemoc.executionframework.engine.ui.launcher
+Automatic-Module-Name: org.eclipse.gemoc.executionframework.engine.ui

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/META-INF/MANIFEST.MF
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/META-INF/MANIFEST.MF
@@ -26,3 +26,4 @@ Export-Package: org.eclipse.gemoc.executionframework.engine,
  org.eclipse.gemoc.executionframework.engine.commons,
  org.eclipse.gemoc.executionframework.engine.core,
  org.eclipse.gemoc.executionframework.engine.profiler
+Automatic-Module-Name: org.eclipse.gemoc.executionframework.engine

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.event.manager/.classpath
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.event.manager/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.event.manager/.settings/org.eclipse.jdt.core.prefs
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.event.manager/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,7 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.event.manager/META-INF/MANIFEST.MF
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.event.manager/META-INF/MANIFEST.MF
@@ -19,3 +19,4 @@ Require-Bundle: fr.inria.diverse.k3.al.annotationprocessor.plugin;bundle-version
  org.eclipse.ocl.ecore
 Bundle-ManifestVersion: 2
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: org.eclipse.gemoc.executionframework.event.manager

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.event.model.edit/META-INF/MANIFEST.MF
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.event.model.edit/META-INF/MANIFEST.MF
@@ -16,3 +16,4 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.ecore.edit;visibility:=reexport,
  org.eclipse.gemoc.executionframework.event.model.edit;visibility:=reexport
 Bundle-ActivationPolicy: lazy
+Automatic-Module-Name: org.eclipse.gemoc.executionframework.event.model.edit

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.event.model.editor/META-INF/MANIFEST.MF
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.event.model.editor/META-INF/MANIFEST.MF
@@ -17,3 +17,4 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui.ide;visibility:=reexport,
  org.eclipse.emf.ecore.edit;visibility:=reexport
 Bundle-ActivationPolicy: lazy
+Automatic-Module-Name: org.eclipse.gemoc.executionframework.event.model.editor

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.event.model/META-INF/MANIFEST.MF
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.event.model/META-INF/MANIFEST.MF
@@ -13,3 +13,4 @@ Export-Package: org.eclipse.gemoc.executionframework.event.model.event,
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.ecore;visibility:=reexport
 Bundle-ActivationPolicy: lazy
+Automatic-Module-Name: org.eclipse.gemoc.executionframework.event.model

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.event.ui/META-INF/MANIFEST.MF
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.event.ui/META-INF/MANIFEST.MF
@@ -16,3 +16,4 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.gemoc.executionframework.event.manager;bundle-version="2.4.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
+Automatic-Module-Name: org.eclipse.gemoc.executionframework.event.ui

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.extensions.sirius/META-INF/MANIFEST.MF
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.extensions.sirius/META-INF/MANIFEST.MF
@@ -29,3 +29,4 @@ Export-Package: org.eclipse.gemoc.executionframework.extensions.sirius,
  org.eclipse.gemoc.executionframework.extensions.sirius.modelloader,
  org.eclipse.gemoc.executionframework.extensions.sirius.services
 Import-Package: org.eclipse.gemoc.trace.commons.model.trace
+Automatic-Module-Name: org.eclipse.gemoc.executionframework.extensions.sirius

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.extensions.sirius/src/org/eclipse/gemoc/executionframework/extensions/sirius/debug/DebugSessionFactory.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.extensions.sirius/src/org/eclipse/gemoc/executionframework/extensions/sirius/debug/DebugSessionFactory.java
@@ -27,9 +27,6 @@ import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.eclipse.emf.transaction.TransactionalEditingDomain;
 import org.eclipse.sirius.business.api.session.Session;
-import org.eclipse.sirius.business.internal.movida.Movida;
-import org.eclipse.sirius.business.internal.movida.registry.ViewpointRegistry;
-import org.eclipse.sirius.business.internal.movida.registry.ViewpointURIConverter;
 import org.eclipse.sirius.business.internal.session.danalysis.DAnalysisSessionImpl;
 import org.eclipse.sirius.common.tools.api.editing.EditingDomainFactoryService;
 import org.eclipse.sirius.common.tools.api.util.SiriusCrossReferenceAdapterImpl;
@@ -69,9 +66,6 @@ public final class DebugSessionFactory {
 		// Configure the resource set, its is done here and not before the
 		// editing domain creation which could provide its own resource set.
 		transactionalEditingDomain.getResourceSet().eAdapters().add(new SiriusCrossReferenceAdapterImpl());
-		if (Movida.isEnabled()) {
-			transactionalEditingDomain.getResourceSet().setURIConverter(new ViewpointURIConverter((ViewpointRegistry) org.eclipse.sirius.business.api.componentization.ViewpointRegistry.getInstance()));
-		}
 
 		// Create or load the session.
 		boolean alreadyExistingResource = exists(sessionResourceURI, transactionalEditingDomain.getResourceSet());

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.ui/META-INF/MANIFEST.MF
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.ui/META-INF/MANIFEST.MF
@@ -22,4 +22,5 @@ Export-Package: org.eclipse.gemoc.executionframework.ui,
  org.eclipse.gemoc.executionframework.ui.views.engine,
  org.eclipse.gemoc.executionframework.ui.views.engine.actions,
  org.eclipse.gemoc.executionframework.ui.xdsml.activefile
+Automatic-Module-Name: org.eclipse.gemoc.executionframework.ui
 

--- a/framework/execution_framework/tests/org.eclipse.gemoc.executionframework.test.lib/META-INF/MANIFEST.MF
+++ b/framework/execution_framework/tests/org.eclipse.gemoc.executionframework.test.lib/META-INF/MANIFEST.MF
@@ -19,3 +19,4 @@ Require-Bundle: com.google.guava,
  org.eclipse.gemoc.executionframework.engine;bundle-version="2.4.0"
 Export-Package: org.eclipse.gemoc.executionframework.test.lib,
  org.eclipse.gemoc.executionframework.test.lib.impl
+Automatic-Module-Name: org.eclipse.gemoc.executionframework.test.lib

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.executionframework.reflectivetrace.model/.classpath
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.executionframework.reflectivetrace.model/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.executionframework.reflectivetrace.model/.settings/org.eclipse.jdt.core.prefs
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.executionframework.reflectivetrace.model/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,7 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.executionframework.reflectivetrace.model/META-INF/MANIFEST.MF
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.executionframework.reflectivetrace.model/META-INF/MANIFEST.MF
@@ -15,3 +15,4 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.ecore.xmi;visibility:=reexport,
  org.eclipse.gemoc.trace.commons.model;bundle-version="0.1.0";visibility:=reexport
 Bundle-ActivationPolicy: lazy
+Automatic-Module-Name: org.eclipse.gemoc.executionframework.reflectivetrace.model

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.opsemanticsview.gen.k3/META-INF/MANIFEST.MF
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.opsemanticsview.gen.k3/META-INF/MANIFEST.MF
@@ -18,3 +18,4 @@ Require-Bundle: org.eclipse.gemoc.opsemanticsview.gen,
  org.eclipse.core.resources;bundle-version="3.11.1",
  org.eclipse.gemoc.xdsmlframework.commons;bundle-version="2.4.0",
  org.eclipse.gemoc.dsl
+Automatic-Module-Name: org.eclipse.gemoc.opsemanticsview.gen.k3

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.opsemanticsview.gen/META-INF/MANIFEST.MF
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.opsemanticsview.gen/META-INF/MANIFEST.MF
@@ -13,4 +13,5 @@ Require-Bundle: com.google.guava,
  org.eclipse.core.resources;bundle-version="3.11.1",
  org.eclipse.gemoc.dsl
 Export-Package: org.eclipse.gemoc.opsemanticsview.gen
+Automatic-Module-Name: org.eclipse.gemoc.opsemanticsview.gen
 

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.opsemanticsview.model/META-INF/MANIFEST.MF
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.opsemanticsview.model/META-INF/MANIFEST.MF
@@ -13,3 +13,4 @@ Export-Package: opsemanticsview,
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.ecore;visibility:=reexport
 Bundle-ActivationPolicy: lazy
+Automatic-Module-Name: org.eclipse.gemoc.opsemanticsview.model

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/META-INF/MANIFEST.MF
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/META-INF/MANIFEST.MF
@@ -20,3 +20,4 @@ Export-Package: org.eclipse.gemoc.xdsmlframework.api,
  org.eclipse.gemoc.xdsmlframework.api.extensions.engine_addon,
  org.eclipse.gemoc.xdsmlframework.api.extensions.engine_addon_group,
  org.eclipse.gemoc.xdsmlframework.api.extensions.languages
+Automatic-Module-Name: org.eclipse.gemoc.xdsmlframework.api

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.commons/META-INF/MANIFEST.MF
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.commons/META-INF/MANIFEST.MF
@@ -7,3 +7,4 @@ Require-Bundle: org.eclipse.emf.ecore,
  org.eclipse.xtend.lib
 Export-Package: org.eclipse.gemoc.xdsmlframework.commons
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: org.eclipse.gemoc.xdsmlframework.commons

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/META-INF/MANIFEST.MF
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/META-INF/MANIFEST.MF
@@ -31,3 +31,4 @@ Export-Package: org.eclipse.gemoc.xdsmlframework.extensions.sirius,
  org.eclipse.gemoc.xdsmlframework.extensions.sirius.command,
  org.eclipse.gemoc.xdsmlframework.extensions.sirius.wizards,
  org.eclipse.gemoc.xdsmlframework.extensions.sirius.wizards.pages
+Automatic-Module-Name: org.eclipse.gemoc.xdsmlframework.extensions.sirius

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.ide.ui/META-INF/MANIFEST.MF
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.ide.ui/META-INF/MANIFEST.MF
@@ -33,4 +33,5 @@ Export-Package: org.eclipse.gemoc.xdsmlframework.ide.ui,
  org.eclipse.gemoc.xdsmlframework.ide.ui.commands,
  org.eclipse.gemoc.xdsmlframework.ide.ui.xdsml.wizards,
  org.eclipse.gemoc.xdsmlframework.ide.ui.xdsml.wizards.pages
+Automatic-Module-Name: org.eclipse.gemoc.xdsmlframework.ide.ui
 

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.ui.utils/META-INF/MANIFEST.MF
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.ui.utils/META-INF/MANIFEST.MF
@@ -15,3 +15,4 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.gemoc.xdsmlframework.ui.utils,
  org.eclipse.gemoc.xdsmlframework.ui.utils.dialogs
+Automatic-Module-Name: org.eclipse.gemoc.xdsmlframework.ui.utils

--- a/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine.ui/META-INF/MANIFEST.MF
+++ b/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine.ui/META-INF/MANIFEST.MF
@@ -42,3 +42,4 @@ Bundle-ActivationPolicy: lazy
 Bundle-ClassPath:  .
 Export-Package: org.eclipse.gemoc.execution.sequential.javaengine.ui,
  org.eclipse.gemoc.execution.sequential.javaengine.ui.launcher
+Automatic-Module-Name: org.eclipse.gemoc.execution.sequential.javaengine.ui

--- a/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine/META-INF/MANIFEST.MF
+++ b/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine/META-INF/MANIFEST.MF
@@ -18,4 +18,5 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: org.eclipse.gemoc.execution.sequential.javaengine
 Bundle-Activator: org.eclipse.gemoc.execution.sequential.javaengine.Activator
 Bundle-ActivationPolicy: lazy
+Automatic-Module-Name: org.eclipse.gemoc.execution.sequential.javaengine
 

--- a/java_execution/java_engine/tests/org.eclipse.gemoc.execution.sequential.javaengine.tests/META-INF/MANIFEST.MF
+++ b/java_execution/java_engine/tests/org.eclipse.gemoc.execution.sequential.javaengine.tests/META-INF/MANIFEST.MF
@@ -18,4 +18,5 @@ Require-Bundle: com.google.guava,
 Export-Package: org.eclipse.gemoc.execution.sequential.javaengine.tests,
  org.eclipse.gemoc.execution.sequential.javaengine.tests.languages,
  org.eclipse.gemoc.execution.sequential.javaengine.tests.wrapper
+Automatic-Module-Name: org.eclipse.gemoc.execution.sequential.javaengine.tests
 

--- a/java_execution/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.api/META-INF/MANIFEST.MF
+++ b/java_execution/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.api/META-INF/MANIFEST.MF
@@ -10,4 +10,5 @@ Require-Bundle: org.eclipse.core.runtime,
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: org.eclipse.gemoc.execution.sequential.javaxdsml.api.extensions.languages
+Automatic-Module-Name: org.eclipse.gemoc.execution.sequential.javaxdsml.api
 

--- a/java_execution/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui/META-INF/MANIFEST.MF
+++ b/java_execution/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui/META-INF/MANIFEST.MF
@@ -43,4 +43,5 @@ Export-Package: org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui,
  org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui.menu,
  org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui.templates,
  org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui.wizards
+Automatic-Module-Name: org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                      http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<prerequisites>
 		<maven>3.0</maven>
@@ -24,9 +27,9 @@
 	</modules>
 
     <properties>
-		<tycho-version>1.0.0</tycho-version>
-    	<xtend.version>2.10.0</xtend.version>
-		<project.build.sourceEncoding>UTF8</project.build.sourceEncoding>
+		<tycho-version>1.2.0</tycho-version>
+    	<xtend.version>2.14.0</xtend.version>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<tycho.scmUrl>scm:git:https://github.com/SiriusLab/ModelDebugging.git</tycho.scmUrl>
 		<!-- <sonar.projectKey>gemoc:${project.groupId}:${project.artifactId}</sonar.projectKey>-->		
 	</properties>
@@ -36,29 +39,29 @@
   	<!--  must NOT include the repositories of the tools included in the Studio has it has its own complementary list -->
 
 		<repository>
-            <id>Oxygen release</id>
+            <id>Photon release</id>
             <layout>p2</layout>
-            <url>http://download.eclipse.org/releases/oxygen</url>
+            <url>http://download.eclipse.org/releases/photon</url>
         </repository>
         <repository>
             <id>kermeta-3</id>
             <layout>p2</layout>
-            <url>http://www.kermeta.org/k3/update_2018-08-14</url>
+            <url>http://www.kermeta.org/k3/update_2018-09-05</url>
         </repository>
         <repository>
             <id>melange</id>
             <layout>p2</layout>
-            <url>http://melange.inria.fr/updatesite/nightly/update_2018-08-14/</url>
+            <url>http://melange.inria.fr/updatesite/nightly/update_2018-09-06/</url>
         </repository>
         <repository>
             <id>elk</id>
             <layout>p2</layout>
-            <url>http://download.eclipse.org/elk/updates/releases/0.1.0/</url>
+            <url>http://download.eclipse.org/elk/updates/releases/0.4.1/</url>
         </repository>
         <repository>
             <id>Sirius</id>
             <layout>p2</layout>
-            <url>http://download.eclipse.org/sirius/updates/releases/5.0.2/oxygen/</url>
+            <url>http://download.eclipse.org/sirius/updates/releases/6.0.1/photon/</url>
         </repository>
 <!--         <repository> -->
 <!--             <id>umldesigner</id> -->
@@ -78,7 +81,7 @@
 	    <repository>
             <id>AspectJ</id>
             <layout>p2</layout>
-            <url>http://download.eclipse.org/tools/ajdt/47/dev/update</url>
+            <url>http://download.eclipse.org/tools/ajdt/48/dev/update</url>
         </repository>
         <!-- <repository>
             <id>javafx</id>
@@ -266,12 +269,31 @@
 						</configuration>
 					</execution>
 				</executions>
+				<!-- workaround https://github.com/eclipse/xtext/issues/1231 -->
+				<dependencies>
+					<dependency>
+						<groupId>org.eclipse.jdt</groupId>
+						<artifactId>org.eclipse.jdt.core</artifactId>
+						<version>3.13.102</version>
+					</dependency>
+					
+					<dependency>
+						<groupId>org.eclipse.jdt</groupId>
+						<artifactId>org.eclipse.jdt.compiler.apt</artifactId>
+						<version>1.3.110</version>
+					</dependency>
+					<dependency>
+						<groupId>org.eclipse.jdt</groupId>
+						<artifactId>org.eclipse.jdt.compiler.tool</artifactId>
+						<version>1.2.101</version>
+					</dependency>
+				</dependencies>
 			</plugin>
             <!-- Java compiler plugin -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.5</version>
+				<version>3.8.0</version>
 				<configuration>
 					<source>1.8</source>
 					<target>1.8</target>
@@ -308,7 +330,7 @@
 			<plugins>
 				<plugin>
 					<artifactId>maven-clean-plugin</artifactId>
-		    		<version>3.0.0</version>
+		    		<version>3.1.0</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>

--- a/simulationmodelanimation/plugins/org.eclipse.gemoc.dsl.debug.edit/META-INF/MANIFEST.MF
+++ b/simulationmodelanimation/plugins/org.eclipse.gemoc.dsl.debug.edit/META-INF/MANIFEST.MF
@@ -13,3 +13,4 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.gemoc.dsl.debug;visibility:=reexport,
  org.eclipse.emf.edit;visibility:=reexport
 Bundle-ActivationPolicy: lazy
+Automatic-Module-Name: org.eclipse.gemoc.dsl.debug.edit

--- a/simulationmodelanimation/plugins/org.eclipse.gemoc.dsl.debug.ide.sirius.ui/META-INF/MANIFEST.MF
+++ b/simulationmodelanimation/plugins/org.eclipse.gemoc.dsl.debug.ide.sirius.ui/META-INF/MANIFEST.MF
@@ -27,3 +27,4 @@ Export-Package: org.eclipse.gemoc.dsl.debug.ide.sirius.ui,
  org.eclipse.gemoc.dsl.debug.ide.sirius.ui.action,
  org.eclipse.gemoc.dsl.debug.ide.sirius.ui.launch,
  org.eclipse.gemoc.dsl.debug.ide.sirius.ui.services
+Automatic-Module-Name: org.eclipse.gemoc.dsl.debug.ide.sirius.ui

--- a/simulationmodelanimation/plugins/org.eclipse.gemoc.dsl.debug.ide.ui/META-INF/MANIFEST.MF
+++ b/simulationmodelanimation/plugins/org.eclipse.gemoc.dsl.debug.ide.ui/META-INF/MANIFEST.MF
@@ -19,3 +19,4 @@ Export-Package: org.eclipse.gemoc.dsl.debug.ide.ui,
  org.eclipse.gemoc.dsl.debug.ide.ui.provider
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.eclipse.gemoc.dsl.debug.ide.ui.DebugIdeUiPlugin$Implementation
+Automatic-Module-Name: org.eclipse.gemoc.dsl.debug.ide.ui

--- a/simulationmodelanimation/plugins/org.eclipse.gemoc.dsl.debug.ide/META-INF/MANIFEST.MF
+++ b/simulationmodelanimation/plugins/org.eclipse.gemoc.dsl.debug.ide/META-INF/MANIFEST.MF
@@ -21,3 +21,4 @@ Export-Package: org.eclipse.gemoc.dsl.debug.ide,
  org.eclipse.gemoc.dsl.debug.ide.event.model,
  org.eclipse.gemoc.dsl.debug.ide.launch
 Bundle-Activator: org.eclipse.gemoc.dsl.debug.ide.Activator
+Automatic-Module-Name: org.eclipse.gemoc.dsl.debug.ide

--- a/simulationmodelanimation/plugins/org.eclipse.gemoc.dsl.debug/META-INF/MANIFEST.MF
+++ b/simulationmodelanimation/plugins/org.eclipse.gemoc.dsl.debug/META-INF/MANIFEST.MF
@@ -13,3 +13,4 @@ Export-Package: org.eclipse.gemoc.dsl.debug,
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.ecore;visibility:=reexport
 Bundle-ActivationPolicy: lazy
+Automatic-Module-Name: org.eclipse.gemoc.dsl.debug

--- a/simulationmodelanimation/pom.xml
+++ b/simulationmodelanimation/pom.xml
@@ -27,7 +27,7 @@
 	</licenses>
 
 	<properties>
-		<tycho-version>1.0.0</tycho-version>
+		<tycho-version>1.2.0</tycho-version>
 		<tycho.scmUrl>scm:git:https://github.com/SiriusLab/ModelDebugging.git</tycho.scmUrl>
 	</properties>
 

--- a/simulationmodelanimation/tests/org.eclipse.gemoc.dsl.debug.ide.tests/META-INF/MANIFEST.MF
+++ b/simulationmodelanimation/tests/org.eclipse.gemoc.dsl.debug.ide.tests/META-INF/MANIFEST.MF
@@ -11,3 +11,4 @@ Require-Bundle: org.eclipse.gemoc.dsl.debug.ide;bundle-version="1.0.0",
  org.eclipse.core.runtime;bundle-version="3.7.0",
  org.eclipse.gemoc.dsl.debug.tests;bundle-version="1.0.0",
  org.junit;bundle-version="4.0.0"
+Automatic-Module-Name: org.eclipse.gemoc.dsl.debug.ide.tests

--- a/simulationmodelanimation/tests/org.eclipse.gemoc.dsl.debug.tests/META-INF/MANIFEST.MF
+++ b/simulationmodelanimation/tests/org.eclipse.gemoc.dsl.debug.tests/META-INF/MANIFEST.MF
@@ -9,3 +9,4 @@ Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.gemoc.dsl.debug;bundle-version="1.0.0",
  org.junit;bundle-version="4.0.0"
 Export-Package: org.eclipse.gemoc.dsl.debug.tests
+Automatic-Module-Name: org.eclipse.gemoc.dsl.debug.tests

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/META-INF/MANIFEST.MF
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/META-INF/MANIFEST.MF
@@ -21,3 +21,4 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.ecore;visibility:=reexport,
  org.eclipse.gemoc.trace.commons.model;visibility:=reexport
 Bundle-ActivationPolicy: lazy
+Automatic-Module-Name: org.eclipse.gemoc.trace.commons.model

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons/META-INF/MANIFEST.MF
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons/META-INF/MANIFEST.MF
@@ -23,4 +23,5 @@ Require-Bundle: com.google.guava,
  org.jdom2;bundle-version="2.0.6"
 Bundle-ClassPath: .
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: org.eclipse.gemoc.trace.commons
 

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.gemoc.api/META-INF/MANIFEST.MF
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.gemoc.api/META-INF/MANIFEST.MF
@@ -15,4 +15,5 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.xtend.lib.macro
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.gemoc.trace.gemoc.api; uses:="org.eclipse.emf.ecore,  org.eclipse.gemoc.executionframework.engine.mse, org.eclipse.gemoc.xdsmlframework.api.engine_addon,  org.eclipse.gemoc.timeline.view"
+Automatic-Module-Name: org.eclipse.gemoc.trace.gemoc.api
 

--- a/trace/generator/plugins/org.eclipse.gemoc.trace.annotations.edit/META-INF/MANIFEST.MF
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.annotations.edit/META-INF/MANIFEST.MF
@@ -15,3 +15,4 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.ecore;visibility:=reexport,
  org.eclipse.emf.ecore.edit;visibility:=reexport
 Bundle-ActivationPolicy: lazy
+Automatic-Module-Name: org.eclipse.gemoc.trace.annotations.edit

--- a/trace/generator/plugins/org.eclipse.gemoc.trace.annotations.editor/META-INF/MANIFEST.MF
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.annotations.editor/META-INF/MANIFEST.MF
@@ -17,3 +17,4 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui.ide;visibility:=reexport,
  org.eclipse.emf.ecore.edit;visibility:=reexport
 Bundle-ActivationPolicy: lazy
+Automatic-Module-Name: org.eclipse.gemoc.trace.annotations.editor

--- a/trace/generator/plugins/org.eclipse.gemoc.trace.annotations/META-INF/MANIFEST.MF
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.annotations/META-INF/MANIFEST.MF
@@ -13,3 +13,4 @@ Export-Package: tracingannotations,
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.ecore;visibility:=reexport
 Bundle-ActivationPolicy: lazy
+Automatic-Module-Name: org.eclipse.gemoc.trace.annotations

--- a/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc.generator/META-INF/MANIFEST.MF
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc.generator/META-INF/MANIFEST.MF
@@ -30,3 +30,4 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.gemoc.trace.gemoc.generator,
  org.eclipse.gemoc.trace.gemoc.generator.codegen,
  org.eclipse.gemoc.trace.gemoc.generator.util
+Automatic-Module-Name: org.eclipse.gemoc.trace.gemoc.generator

--- a/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc.ui/META-INF/MANIFEST.MF
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc.ui/META-INF/MANIFEST.MF
@@ -23,3 +23,4 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.10.0",
  org.eclipse.gemoc.xdsmlframework.ui.utils;bundle-version="0.1.0",
  org.eclipse.gemoc.commons.eclipse;bundle-version="0.1.0"
 Bundle-ActivationPolicy: lazy
+Automatic-Module-Name: org.eclipse.gemoc.trace.gemoc.ui

--- a/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/META-INF/MANIFEST.MF
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/META-INF/MANIFEST.MF
@@ -18,4 +18,5 @@ Require-Bundle: org.eclipse.gemoc.timeline;bundle-version="1.0.0",
 Export-Package: org.eclipse.gemoc.trace.gemoc.traceaddon
 Bundle-ActivationPolicy: lazy
 Import-Package: org.eclipse.gemoc.executionframework.debugger
+Automatic-Module-Name: org.eclipse.gemoc.trace.gemoc
 

--- a/trace/generator/plugins/org.eclipse.gemoc.trace.metamodel.generator/META-INF/MANIFEST.MF
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.metamodel.generator/META-INF/MANIFEST.MF
@@ -29,4 +29,5 @@ Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: org.eclipse.gemoc.trace.metamodel.generator
 

--- a/trace/manager/plugins/org.eclipse.gemoc.addon.diffviewer/META-INF/MANIFEST.MF
+++ b/trace/manager/plugins/org.eclipse.gemoc.addon.diffviewer/META-INF/MANIFEST.MF
@@ -15,3 +15,4 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.gemoc.trace.commons.model;bundle-version="2.4.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
+Automatic-Module-Name: org.eclipse.gemoc.addon.diffviewer

--- a/trace/manager/plugins/org.eclipse.gemoc.addon.multidimensional.timeline/META-INF/MANIFEST.MF
+++ b/trace/manager/plugins/org.eclipse.gemoc.addon.multidimensional.timeline/META-INF/MANIFEST.MF
@@ -27,4 +27,5 @@ Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.gemoc.addon.multidimensional.timeline,
  org.eclipse.gemoc.addon.multidimensional.timeline.views
+Automatic-Module-Name: org.eclipse.gemoc.addon.multidimensional.timeline
 

--- a/trace/manager/plugins/org.eclipse.gemoc.addon.stategraph/META-INF/MANIFEST.MF
+++ b/trace/manager/plugins/org.eclipse.gemoc.addon.stategraph/META-INF/MANIFEST.MF
@@ -24,3 +24,4 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.fx.core
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
+Automatic-Module-Name: org.eclipse.gemoc.addon.stategraph

--- a/trace/manager/plugins/org.eclipse.gemoc.addon.stategraph/src/org/eclipse/gemoc/addon/stategraph/layout/StateGraphLayoutCommand.java
+++ b/trace/manager/plugins/org.eclipse.gemoc.addon.stategraph/src/org/eclipse/gemoc/addon/stategraph/layout/StateGraphLayoutCommand.java
@@ -14,13 +14,13 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import org.eclipse.elk.alg.layered.p2layers.LayeringStrategy;
-import org.eclipse.elk.alg.layered.properties.LayeredOptions;
+import org.eclipse.elk.alg.layered.options.LayeringStrategy;
+import org.eclipse.elk.alg.layered.options.LayeredOptions;
 import org.eclipse.elk.core.LayoutConfigurator;
 import org.eclipse.elk.core.options.CoreOptions;
 import org.eclipse.elk.core.service.DiagramLayoutEngine;
 import org.eclipse.elk.core.service.DiagramLayoutEngine.Parameters;
-import org.eclipse.elk.graph.KNode;
+import org.eclipse.elk.graph.ElkNode;
 import org.eclipse.elk.graph.properties.Property;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.gemoc.addon.stategraph.logic.StateVertex;
@@ -40,11 +40,11 @@ public class StateGraphLayoutCommand {
 	public void applyLayout(Map<StateVertex, VertexView> nodeToShape, Set<StateVertex> movedVertice) {
 		Parameters params = new Parameters();
 		LayoutConfigurator configurator = new LayoutConfigurator();
-		configurator.configure(KNode.class)
+		configurator.configure(ElkNode.class)
 				.setProperty(CoreOptions.ALGORITHM, "org.eclipse.elk.layered")
 				.setProperty(LayeredOptions.LAYERING_STRATEGY, LayeringStrategy.COFFMAN_GRAHAM)
 				.setProperty(LayeredOptions.LAYERING_COFFMAN_GRAHAM_LAYER_BOUND, 5)
-				.setProperty(CoreOptions.SPACING_NODE, 50.0f)
+				.setProperty(CoreOptions.SPACING_NODE_NODE, 50.0)
 				.setProperty(VERTEX2SHAPE_MAP, nodeToShape);
 		params.addLayoutRun(configurator);
 		DiagramLayoutEngine.invokeLayout(workbenchPart, null, params);

--- a/trace/manager/plugins/org.eclipse.gemoc.addon.stategraph/src/org/eclipse/gemoc/addon/stategraph/layout/StateGraphLayoutConnector.java
+++ b/trace/manager/plugins/org.eclipse.gemoc.addon.stategraph/src/org/eclipse/gemoc/addon/stategraph/layout/StateGraphLayoutConnector.java
@@ -19,17 +19,17 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.eclipse.elk.core.klayoutdata.KShapeLayout;
 import org.eclipse.elk.core.math.KVector;
 import org.eclipse.elk.core.options.CoreOptions;
 import org.eclipse.elk.core.service.IDiagramLayoutConnector;
 import org.eclipse.elk.core.service.LayoutMapping;
 import org.eclipse.elk.core.util.ElkUtil;
-import org.eclipse.elk.graph.KEdge;
-import org.eclipse.elk.graph.KGraphElement;
-import org.eclipse.elk.graph.KNode;
+import org.eclipse.elk.graph.ElkEdge;
+import org.eclipse.elk.graph.ElkGraphElement;
+import org.eclipse.elk.graph.ElkNode;
 import org.eclipse.elk.graph.properties.IPropertyHolder;
 import org.eclipse.elk.graph.properties.Property;
+import org.eclipse.elk.graph.util.ElkGraphUtil;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.gemoc.addon.stategraph.logic.DirectedGraph;
 import org.eclipse.gemoc.addon.stategraph.logic.StateGraph;
@@ -53,7 +53,7 @@ public class StateGraphLayoutConnector implements IDiagramLayoutConnector {
 		LayoutMapping mapping = new LayoutMapping(workbenchPart);
 		mapping.setParentElement(layoutRootPart);
 
-		KNode topNode = ElkUtil.createInitializedNode();
+		ElkNode topNode = ElkGraphUtil.createNode(null);
 		mapping.getGraphMap().put(topNode, layoutRootPart);
 		mapping.setLayoutGraph(topNode);
 
@@ -63,7 +63,7 @@ public class StateGraphLayoutConnector implements IDiagramLayoutConnector {
 		vertice.removeAll(movedVertice);
 
 		for (StateVertex vertex : vertice) {
-			KNode node = createNode(mapping, vertex, topNode);
+			ElkNode node = createNode(mapping, vertex, topNode);
 			mapping.getGraphMap().put(node, vertex);
 		}
 
@@ -72,28 +72,28 @@ public class StateGraphLayoutConnector implements IDiagramLayoutConnector {
 				.collect(Collectors.toList());
 
 		for (DirectedGraph.Edge<StateVertex> edge : edges) {
-			KEdge kEdge = createEdge(mapping, edge);
+			ElkEdge kEdge = createEdge(mapping, edge);
 			mapping.getGraphMap().put(kEdge, edge);
 		}
 
 		return mapping;
 	}
 
-	private KNode createNode(final LayoutMapping mapping, final StateVertex nodeStateVertex, final KNode rootNode) {
-		KNode childLayoutNode = ElkUtil.createInitializedNode();
+	private ElkNode createNode(final LayoutMapping mapping, final StateVertex nodeStateVertex, final ElkNode rootNode) {
+		ElkNode childLayoutNode = ElkGraphUtil.createNode(null);
 		rootNode.getChildren().add(childLayoutNode);
-		KShapeLayout nodeLayout = childLayoutNode.getData(KShapeLayout.class);
+		/* KShapeLayout nodeLayout = childLayoutNode.getData(KShapeLayout.class);
 		nodeLayout.setSize(24, 24);
 		((KShapeLayout) nodeLayout).resetModificationFlag();
-		nodeLayout.setProperty(CoreOptions.NODE_SIZE_MINIMUM, new KVector(24, 24));
+		nodeLayout.setProperty(CoreOptions.NODE_SIZE_MINIMUM, new KVector(24, 24)); */
 		mapping.getGraphMap().put(childLayoutNode, nodeStateVertex);
 		return childLayoutNode;
 	}
 
-	private KEdge createEdge(final LayoutMapping mapping, final DirectedGraph.Edge<StateVertex> edge) {
-		KEdge layoutEdge = ElkUtil.createInitializedEdge();
-		layoutEdge.setSource((KNode) mapping.getGraphMap().inverse().get(edge.getSource()));
-		layoutEdge.setTarget((KNode) mapping.getGraphMap().inverse().get(edge.getTarget()));
+	private ElkEdge createEdge(final LayoutMapping mapping, final DirectedGraph.Edge<StateVertex> edge) {
+		ElkEdge layoutEdge = ElkGraphUtil.createEdge(null);
+		layoutEdge.getSources().add((ElkNode) mapping.getGraphMap().inverse().get(edge.getSource()));
+		layoutEdge.getTargets().add((ElkNode) mapping.getGraphMap().inverse().get(edge.getTarget()));
 		mapping.getGraphMap().put(layoutEdge, edge);
 		return layoutEdge;
 	}
@@ -103,8 +103,8 @@ public class StateGraphLayoutConnector implements IDiagramLayoutConnector {
 
 	@Override
 	public void applyLayout(LayoutMapping layoutMapping, IPropertyHolder propertyHolder) {
-		for (Entry<KGraphElement, Object> entry : layoutMapping.getGraphMap().entrySet()) {
-			final KShapeLayout layout = entry.getKey().getData(KShapeLayout.class);
+		for (Entry<ElkGraphElement, Object> entry : layoutMapping.getGraphMap().entrySet()) {
+			/* final KShapeLayout layout = entry.getKey().getData(KShapeLayout.class);
 			if (layout != null) {
 				final double xPos = layout.getXpos();
 				final double yPos = layout.getYpos();
@@ -113,7 +113,7 @@ public class StateGraphLayoutConnector implements IDiagramLayoutConnector {
 					v.setTranslateX(xPos);
 					v.setTranslateY(yPos);
 				});
-			}
+			} */
 		}
 	}
 }

--- a/trace/tests_and_benchmarks/org.eclipse.gemoc.trace.commons.testutil/META-INF/MANIFEST.MF
+++ b/trace/tests_and_benchmarks/org.eclipse.gemoc.trace.commons.testutil/META-INF/MANIFEST.MF
@@ -12,4 +12,5 @@ Require-Bundle: com.google.guava,
  org.eclipse.emf.ecore;bundle-version="2.10.2"
 Export-Package: org.eclipse.gemoc.trace.commons.testutil
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: org.eclipse.gemoc.trace.commons.testutil
 

--- a/trace/tests_and_benchmarks/org.eclipse.gemoc.trace.gemoc.generator.test/META-INF/MANIFEST.MF
+++ b/trace/tests_and_benchmarks/org.eclipse.gemoc.trace.gemoc.generator.test/META-INF/MANIFEST.MF
@@ -15,4 +15,5 @@ Require-Bundle: com.google.guava,
  org.eclipse.emf.ecore,
  org.eclipse.gemoc.trace.commons;bundle-version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Automatic-Module-Name: org.eclipse.gemoc.trace.gemoc.generator.test
 

--- a/trace/tests_and_benchmarks/org.eclipse.gemoc.trace.metamodel.generator.test/.classpath
+++ b/trace/tests_and_benchmarks/org.eclipse.gemoc.trace.metamodel.generator.test/.classpath
@@ -1,8 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="xtend-gen"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="xtend-gen">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="src">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/trace/tests_and_benchmarks/org.eclipse.gemoc.trace.metamodel.generator.test/.settings/org.eclipse.jdt.core.prefs
+++ b/trace/tests_and_benchmarks/org.eclipse.gemoc.trace.metamodel.generator.test/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,7 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/trace/tests_and_benchmarks/org.eclipse.gemoc.trace.metamodel.generator.test/META-INF/MANIFEST.MF
+++ b/trace/tests_and_benchmarks/org.eclipse.gemoc.trace.metamodel.generator.test/META-INF/MANIFEST.MF
@@ -13,4 +13,5 @@ Require-Bundle: org.eclipse.xtend.lib,
  org.eclipse.gemoc.trace.metamodel.generator;bundle-version="1.0.0",
  org.eclipse.core.runtime;bundle-version="3.9.100",
  org.eclipse.gemoc.trace.commons;bundle-version="1.0.0"
+Automatic-Module-Name: org.eclipse.gemoc.trace.metamodel.generator.test
 

--- a/trace/tests_and_benchmarks/org.eclipse.gemoc.trace.plugin.generator.test/META-INF/MANIFEST.MF
+++ b/trace/tests_and_benchmarks/org.eclipse.gemoc.trace.plugin.generator.test/META-INF/MANIFEST.MF
@@ -16,4 +16,5 @@ Require-Bundle: com.google.guava,
  org.eclipse.emf.ecore,
  org.eclipse.gemoc.trace.commons;bundle-version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Automatic-Module-Name: org.eclipse.gemoc.trace.plugin.generator.test
 


### PR DESCRIPTION
* several version bumps
     to photon
     to xtend 2.14
     to melange 0.2.2
     to k3
     to tycho 1.2.0
     maven compiler and clean plugins
* remove movida related code
     this has been removed from Sirius in 6.x.x
     https://bugs.eclipse.org/bugs/show_bug.cgi?id=462311
* bump elk to 0.4.1 + fix
     Tried to fix for latest version, disabled some KShapeLayout stuff I
     didn't retrieve in latest version, need further test ...
* use UTF-8 instead of UTF8 for encoding declaration
* add Automatic-Module-Name
     contribute to https://github.com/eclipse/gemoc-studio/issues/115

Signed-off-by: Didier Vojtisek <didier.vojtisek@inria.fr>